### PR TITLE
Replace local paths in Gemfile with git paths

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,20 +3,20 @@ source 'https://rubygems.org'
 gem 'rails', '4.2.1'
 gem 'unicorn'
 
-gem 'base-n', :path => "./vendor/local/base-n"
-gem 'dumber', :path => "./vendor/local/dumber"
+gem 'base-n', :git => "https://github.com/skiprope/base-n.git"
+gem 'dumber', :git => "https://github.com/skiprope/dumber.git"
 
 gem 'sass-rails', '~> 5.0'
 
 gem 'uglifier', '>= 1.3.0'
 
 gem 'coffee-rails', '~> 4.1.0'
-gem 'livescript-rails', ">= 1.1.0", :path => "./vendor/local/livescript-rails"
+gem 'livescript-rails', ">= 1.1.0", :git => "https://github.com/skiprope/livescript-rails.git"
 
 gem 'haml'
 gem 'haml-rails'
 
-gem 'maruku-dirty', :path => "./vendor/local/maruku"
+gem 'maruku-dirty', :git => "https://github.com/skiprope/maruku-dirty.git"
 gem 'motion-markdown-it'
 
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,18 @@
-PATH
-  remote: ./vendor/local/base-n
+GIT
+  remote: https://github.com/skiprope/base-n.git
+  revision: 58ca413e433cc2bae5f1badbb7d7c9a3b0874a18
   specs:
     base-n (1.0.0)
 
-PATH
-  remote: ./vendor/local/dumber
+GIT
+  remote: https://github.com/skiprope/dumber.git
+  revision: bf0caec8b4d339528a222368c22f290e93e3cb37
   specs:
     dumber (1.0.0)
 
-PATH
-  remote: ./vendor/local/livescript-rails
+GIT
+  remote: https://github.com/skiprope/livescript-rails.git
+  revision: 5f8633df735b23bce377071d9e7d2fbd35ddaa34
   specs:
     livescript-rails (1.1.1)
       execjs
@@ -17,8 +20,9 @@ PATH
       railties
       tilt
 
-PATH
-  remote: ./vendor/local/maruku
+GIT
+  remote: https://github.com/skiprope/maruku-dirty.git
+  revision: 78112f9223787b92c2dbd19417d6ed2888255352
   specs:
     maruku-dirty (0.7.2)
 

--- a/db/migrate/20150330121956_add_screen_name_and_display_name_to_users.rb
+++ b/db/migrate/20150330121956_add_screen_name_and_display_name_to_users.rb
@@ -1,0 +1,7 @@
+class AddScreenNameAndDisplayNameToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :screen_name, :string
+    add_index :users, :screen_name, unique: true
+    add_column :users, :display_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150330103042) do
+ActiveRecord::Schema.define(version: 20150330121956) do
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "", null: false
@@ -26,9 +26,12 @@ ActiveRecord::Schema.define(version: 20150330103042) do
     t.string   "last_sign_in_ip"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "screen_name"
+    t.string   "display_name"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  add_index "users", ["screen_name"], name: "index_users_on_screen_name", unique: true
 
 end


### PR DESCRIPTION
[Using git in Gemfiles](http://bundler.io/git.html) is better, or in fact easier to manage than using git submodules, because they can end up breaking a lot of stuff.

With this, the gems will be updated from the corresponding git repository everytime you run `bundle install`

I also added screen names (usernames) and display names to users.